### PR TITLE
feat/banner mobile

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "details": [
       {
         "appIDs": [
-          "TJU8M52QQJ.FPU2P52CDD"
+          "TJU8M52QQJ.com.vegacheckout.app"
         ],
         "components": [
           {
@@ -16,12 +16,12 @@
   },
   "activitycontinuation": {
     "apps": [
-      "TJU8M52QQJ.FPU2P52CDD"
+      "TJU8M52QQJ.com.vegacheckout.app"
     ]
   },
   "webcredentials": {
     "apps": [
-      "TJU8M52QQJ.FPU2P52CDD"
+      "TJU8M52QQJ.com.vegacheckout.app"
     ]
   }
 }

--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,27 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "TJU8M52QQJ.com.vegacheckout.app"
+        ],
+        "components": [
+          {
+            "/": "*",
+            "comment": "Matches all routes"
+          }
+        ]
+      }
+    ]
+  },
+  "activitycontinuation": {
+    "apps": [
+      "TJU8M52QQJ.com.vegacheckout.app"
+    ]
+  },
+  "webcredentials": {
+    "apps": [
+      "TJU8M52QQJ.com.vegacheckout.app"
+    ]
+  }
+}

--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "details": [
       {
         "appIDs": [
-          "TJU8M52QQJ.com.vegacheckout.app"
+          "TJU8M52QQJ.FPU2P52CDD"
         ],
         "components": [
           {
@@ -16,12 +16,12 @@
   },
   "activitycontinuation": {
     "apps": [
-      "TJU8M52QQJ.com.vegacheckout.app"
+      "TJU8M52QQJ.FPU2P52CDD"
     ]
   },
   "webcredentials": {
     "apps": [
-      "TJU8M52QQJ.com.vegacheckout.app"
+      "TJU8M52QQJ.FPU2P52CDD"
     ]
   }
 }

--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -13,15 +13,5 @@
         ]
       }
     ]
-  },
-  "activitycontinuation": {
-    "apps": [
-      "TJU8M52QQJ.com.vegacheckout.app"
-    ]
-  },
-  "webcredentials": {
-    "apps": [
-      "TJU8M52QQJ.com.vegacheckout.app"
-    ]
   }
 }

--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
   <link rel="canonical" href="https://vegacheckout.com.br/">
+
+  <meta name="apple-itunes-app" content="app-id=6745680580" />
   
 
 </head>

--- a/index.html
+++ b/index.html
@@ -30,12 +30,15 @@
   <!-- Status & Address Bar colour -->
   <meta name="theme-color" content="#EFE3CD">
   <!-- iOS Safari -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta property="al:ios:app_name" content="Vega Checkout" />
+  <meta property="al:ios:app_store_id" content="6745626009" />
+  <meta property="al:ios:url" content="vegacheckout:///" />
+  <meta name="apple-itunes-app" content="app-id=6745626009" />
 
   <link rel="canonical" href="https://vegacheckout.com.br/">
 
-  <meta name="apple-itunes-app" content="app-id=6745626009" />
   
 
 </head>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 
   <link rel="canonical" href="https://vegacheckout.com.br/">
 
-  <meta name="apple-itunes-app" content="app-id=6745680580" />
+  <meta name="apple-itunes-app" content="app-id=6745626009" />
   
 
 </head>


### PR DESCRIPTION
This pull request introduces support for deep linking and enhances metadata for iOS devices to improve the user experience when interacting with the Vega Checkout app. The changes include adding an Apple App Site Association file and updating the HTML metadata for iOS app integration.

### Deep linking support:

* [`.well-known/apple-app-site-association`](diffhunk://#diff-b699af4a3420bb85f0bba364afdf2fd1f91fb4c22e9e85bca12183b96e3e02ceR1-R17): Added an Apple App Site Association file to enable universal links for the Vega Checkout app, matching all routes to the app.

### iOS metadata enhancements:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L33-R43): Updated metadata to include iOS app integration properties (`al:ios:app_name`, `al:ios:app_store_id`, `al:ios:url`, and `apple-itunes-app`) and adjusted the `apple-mobile-web-app-status-bar-style` to "default".